### PR TITLE
adds simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+CFLAGS   = -Wall -std=c99
+CPPFLAGS = -DNDEBUG
+LDFLAGS  = -lm
+
+INSTALL     = install
+INSTALL_BIN = $(INSTALL) -D -m 755
+
+prefix  = /usr/local
+bindir  = $(prefix)/bin
+
+.PHONY: all
+all: src/wave
+
+src/wave: src/wave.c
+
+.PHONY: install
+install: all
+	$(INSTALL_BIN) src/wave $(bindir)/wave
+
+.PHONY: uninstall
+uninstall:
+	$(RM) $(bindir)/wave
+
+.PHONY: clean
+clean:
+	$(RM) src/wave


### PR DESCRIPTION
I didn't edit `README` because I am not sure if I should remove the manual compilation command or leave it there.

It should mention commands:

```
make
make prefix=/path/to install
make prefix=/path/to uninstall
```
