### PR TITLE
fixes warnings (with -Wextra)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS   = -Wall -std=c99
-CPPFLAGS = -DNDEBUG
+CFLAGS   = -Wall -Wextra -std=c99
+CPPFLAGS = -D_GNU_SOURCE -DNDEBUG
 LDFLAGS  = -lm
 
 INSTALL     = install

--- a/src/wave.c
+++ b/src/wave.c
@@ -44,8 +44,8 @@
 #define MAX_FREQS 10
 #endif
 
-const static double TWO_PI = 2*M_PI;
-const static char* LONG_HELP_STR = "Outputs a binary sine wave with the specified frequencies.\n"
+static const double TWO_PI = 2*M_PI;
+static const char* LONG_HELP_STR = "Outputs a binary sine wave with the specified frequencies.\n"
 "\n"
 "options:\n"
 "\n"


### PR DESCRIPTION
`-Wextra` is added to Makefile for extra warnings, this warns static should be at beginning of declaration.

Adding `-D_GNU_SOURCE` fixes implicit declaration and integer to pointer without a cast

The warnings are (with `-Wextra`):

```
% make
cc -Wall -Wextra -std=c99 -DNDEBUG -lm  src/wave.c   -o src/wave
src/wave.c:47:1: warning: 'static' is not at beginning of declaration [-Wold-style-declaration]
src/wave.c:48:1: warning: 'static' is not at beginning of declaration [-Wold-style-declaration]
src/wave.c: In function 'start_wave':
src/wave.c:286:5: warning: implicit declaration of function 'strtok_r' [-Wimplicit-function-declaration]
src/wave.c:286:9: warning: assignment makes pointer from integer without a cast [enabled by default]
src/wave.c:298:9: warning: assignment makes pointer from integer without a cast [enabled by default]
src/wave.c: In function 'get_all_frequencies':
src/wave.c:353:11: warning: assignment makes pointer from integer without a cast [enabled by default]
src/wave.c:355:11: warning: assignment makes pointer from integer without a cast [enabled by default]
```
